### PR TITLE
Add missing string to lang/en

### DIFF
--- a/action.php
+++ b/action.php
@@ -255,41 +255,7 @@ function perform_deletion($modules) {
             print_error('modulemissingcode', '', '', $modlib);
         }
 
-        if (function_exists('course_delete_module')) {
-            // available from Moodle 2.5
-            course_delete_module($cm->id);
-        }
-        else {
-            // pre Moodle 2.5
-            $deleteinstancefunction = $cm->modname."_delete_instance";
-
-            if (!$deleteinstancefunction($cm->instance)) {
-                echo $OUTPUT->notification("Could not delete the $cm->modname (instance)");
-            }
-
-            // remove all module files in case modules forget to do that
-            $fs = get_file_storage();
-            $fs->delete_area_files($modcontext->id);
-
-            if (!delete_course_module($cm->id)) {
-                echo $OUTPUT->notification("Could not delete the $cm->modname (coursemodule)");
-            }
-            if (!delete_mod_from_section($cm->id, $cm->section)) {
-                echo $OUTPUT->notification("Could not delete the $cm->modname from that section");
-            }
-
-            // Trigger a mod_deleted event with information about this module.
-            $eventdata = new stdClass();
-            $eventdata->modulename = $cm->modname;
-            $eventdata->cmid       = $cm->id;
-            $eventdata->courseid   = $course->id;
-            $eventdata->userid     = $USER->id;
-            events_trigger('mod_deleted', $eventdata);
-
-            add_to_log($course->id, 'course', "delete mod",
-                       "view.php?id=$cm->course",
-                       "$cm->modname $cm->instance", $cm->id);
-        }
+        course_delete_module($cm->id);
     }
 }
 

--- a/lang/en/block_massaction.php
+++ b/lang/en/block_massaction.php
@@ -1,5 +1,6 @@
 <?php
 $string['pluginname'] = 'Mass action block';
+$string['massaction:addinstance'] = 'Add a new Mass Actions block';
 $string['massaction:use'] = 'Use the Mass Actions block';
 $string['blockname'] = 'Mass Actions';
 $string['blocktitle'] = 'Mass Actions';

--- a/version.php
+++ b/version.php
@@ -1,5 +1,8 @@
 <?php
-$plugin->version = 2013112101;  // YYYYMMDDHH (year, month, day, 24-hr time)
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version = 2013120600;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires = 2012110900; // YYYYMMDDHH (This is the release version for Moodle 2.0)
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Mass Actions Block';

--- a/version.php
+++ b/version.php
@@ -2,7 +2,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2013120600;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2014062300;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires = 2012110900; // YYYYMMDDHH (This is the release version for Moodle 2.0)
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Mass Actions Block';


### PR DESCRIPTION
Adds a missing string for 'addinstance' message.
This is for compatibility with Moodle 2.3 onwards
